### PR TITLE
add "flat" dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-release": "^0.13.0"
+  },
+  "dependencies": {
+    "flat": "^2.0.1"
   }
 }


### PR DESCRIPTION
The `flat` library is required but is not included in the package.json dependecies, causing it to throw an error. This adds `flat` to the dependencies.
